### PR TITLE
fix: use django's undeprecated gettext_lazy

### DIFF
--- a/setfield/__init__.py
+++ b/setfield/__init__.py
@@ -1,6 +1,6 @@
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 class SetField(ArrayField):
     """Stores set objects.


### PR DESCRIPTION
This commit solves deprecation warnings produced by django.

Signed-off-by: Kevin Morris <kevr@0cost.org>